### PR TITLE
added int return value

### DIFF
--- a/src/MHZ19.cpp
+++ b/src/MHZ19.cpp
@@ -25,12 +25,12 @@ byte Commands[14] = {
 
 /*#####################-Initiation Functions-#####################*/
 
-void MHZ19::begin(Stream &serial)
+int MHZ19::begin(Stream &serial)
 {
     mySerial = &serial;
 
     /* establish connection */
-    verify();
+    if (verify()) return 1;
 
     /* check if successful */
     if (this->errorCode != RESULT_OK)
@@ -48,6 +48,7 @@ void MHZ19::begin(Stream &serial)
 
     /* Store the major version number (assumed to be less than 10) */
     this->storage.settings.fw_ver = myVersion[1];
+    return 0;
 }
 
 /*########################-Set Functions-##########################*/
@@ -326,7 +327,7 @@ bool MHZ19::getABC()
 
 /*######################-Utility Functions-########################*/
 
-void MHZ19::verify()
+int MHZ19::verify()
 {
     unsigned long timeStamp = millis();
 
@@ -345,7 +346,7 @@ void MHZ19::verify()
             Serial.println("!ERROR: Failed to verify connection(1) to sensor.");
             #endif
 
-            return;
+            return 1;
         }
     }
 
@@ -366,7 +367,7 @@ void MHZ19::verify()
             Serial.println("!ERROR: Failed to verify connection(2) to sensor.");
             #endif
 
-            return;
+            return 1;
         }
     }
 
@@ -381,10 +382,10 @@ void MHZ19::verify()
             Serial.println("!ERROR: Last response is not as expected, verification failed.");
             #endif
 
-            return;
+            return 1;
         }
     }
-    return;
+    return 0;
 }
 
 void MHZ19::autoCalibration(bool isON, byte ABCPeriod)

--- a/src/MHZ19.h
+++ b/src/MHZ19.h
@@ -44,8 +44,8 @@ class MHZ19
 
 	/*#####################-Initiation Functions-#####################*/
 
-	/* essential begin */
-	void begin(Stream &stream);
+	/* essential begin, return 0 on success, non-zero on error */
+	int begin(Stream &stream);
 
 	/*########################-Set Functions-##########################*/
 
@@ -98,8 +98,10 @@ class MHZ19
 
 	/*######################-Utility Functions-########################*/
 
-	/* ensure communication is working (included in begin())*/
-	void verify();
+	/* ensure communication is working (included in begin())
+	 * return 0 on success, non-zero on error
+	 */
+	int verify();
 
 	/* disables calibration or sets ABCPeriod */
 	void autoCalibration(bool isON = true, byte ABCPeriod = 24);


### PR DESCRIPTION
added int return value to verify and begin functions to check if sensor connection failed.
I found it useful to have some indication whether a sensor might be attached or not . with this change one could use code like this:
```
  co2Serial.begin(9600);
  if (0 == co2MHZ19.begin(co2Serial)) {
    co2MHZ19OK = true;
    co2MHZ19.autoCalibration();
  }

```
not sure if you want to integrate this or not?